### PR TITLE
Removed upgrade and compile.

### DIFF
--- a/static-tests.sh
+++ b/static-tests.sh
@@ -5,6 +5,4 @@ git fetch
 git checkout origin/$1
 cd ../../../../
 
-bin/magento setup:upgrade &&
-bin/magento setup:di:compile &&
 vendor/bin/phpstan analyse --no-progress -c /home/owner/scripts/phpstan.neon app/code/Firebear/ImportExport


### PR DESCRIPTION
Magento upgrade and compile are runs by a separate step in bitbucket-pipelines.yml